### PR TITLE
[Fix] target_ovr: Assume 100% if missing battery

### DIFF
--- a/BridgeApp/target_ovr.py
+++ b/BridgeApp/target_ovr.py
@@ -51,13 +51,19 @@ class OpenVRTracker:
 
     def get_model(self, index):
         try:
-            result = self.vr.getStringTrackedDeviceProperty(index, openvr.Prop_ModelNumber_String)
+            return self.vr.getStringTrackedDeviceProperty(index, openvr.Prop_ModelNumber_String)
         except openvr.error_code.TrackedProp_UnknownProperty:
-            result = "Unknown Tracker"
-        return result
+            # Some devices (e.g. Vive Tracker 1.0) don't report a model number.
+            return "Unknown Tracker"
 
     def get_battery_level(self, index):
-        return self.vr.getFloatTrackedDeviceProperty(index, openvr.Prop_DeviceBatteryPercentage_Float)
+        try:
+            return self.vr.getFloatTrackedDeviceProperty(index, openvr.Prop_DeviceBatteryPercentage_Float)
+        except openvr.error_code.TrackedProp_UnknownProperty:
+            # Some devices (e.g. Tundra Trackers) may be delayed in reporting a
+            # battery percentage, especially if fully charged.  If missing,
+            # assume 100% battery.
+            return 1
 
     def set_strength(self, serial, strength):
         if serial in self.vibration_managers:


### PR DESCRIPTION
## In short
* Assume 100% battery charge (`1.0`) if missing the battery percentage float
   * Fixes some devices (e.g. Tundra Trackers) that don't immediately report their battery status
* Skip intermediate variables and return the value directly

*~~I cleaned this up from an earlier hack, so I haven't tested this exact code.  I'll mark the pull request as ready once I get a chance to test this iteration.~~*

*EDIT 2024-3-20: Tested, seems to work.*