### PR TITLE
ci: Add GitHub Actions PyInstaller builder

### DIFF
--- a/.github/workflows/build-pyinstaller.yml
+++ b/.github/workflows/build-pyinstaller.yml
@@ -1,0 +1,61 @@
+name: Build with PyInstaller
+
+# From https://github.com/sayyid5416/pyinstaller
+
+on:
+  push:
+  pull_request:
+
+# Get git tag info via GitHub API due to shallow clone:
+# See https://github.com/marketplace/actions/gh-describe
+# And https://stackoverflow.com/questions/66349002/get-latest-tag-git-describe-tags-when-repo-is-cloned-with-depth-1
+# And https://dev.to/hectorleiva/github-actions-and-creating-a-short-sha-hash-8b7
+
+jobs:
+  pyinstall-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v2
+        with:
+          default: "notags-${{ github.sha }}"
+      - name: Check outputs
+        run: |
+          echo "describe  : ${{ steps.ghd.outputs.describe }}"
+          echo "tag       : ${{ steps.ghd.outputs.tag }}"
+          echo "distance  : ${{ steps.ghd.outputs.distance }}"
+          echo "sha       : ${{ steps.ghd.outputs.sha }}"
+          echo "short-sha : ${{ steps.ghd.outputs.short-sha }}"
+      - name: Build executable
+        uses: sayyid5416/pyinstaller@v1
+        with:
+          spec: 'hapticpancake.spec'
+          requirements: 'BridgeApp/requirements.txt'
+          upload_exe_with_name: 'hapticpancake_windows_${{ steps.ghd.outputs.describe }}'
+          # options: --onefile, --windowed, --collect-all openvr, --name "hapticpancake", --icon=Images\icon.ico
+          # These options are not used when passing in a .spec file
+
+  pyinstall-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git describe
+        id: ghd
+        uses: proudust/gh-describe@v2
+        with:
+          default: "notags-${{ github.sha }}"
+      - name: Check outputs
+        run: |
+          echo "describe  : ${{ steps.ghd.outputs.describe }}"
+          echo "tag       : ${{ steps.ghd.outputs.tag }}"
+          echo "distance  : ${{ steps.ghd.outputs.distance }}"
+          echo "sha       : ${{ steps.ghd.outputs.sha }}"
+          echo "short-sha : ${{ steps.ghd.outputs.short-sha }}"
+      - name: Build executable
+        uses: sayyid5416/pyinstaller@v1
+        with:
+          spec: 'hapticpancake.spec'
+          requirements: 'BridgeApp/requirements.txt'
+          upload_exe_with_name: 'hapticpancake_linux_${{ steps.ghd.outputs.describe }}'
+          # options: --onefile, --windowed, --collect-all openvr, --name "hapticpancake", --icon=Images\icon.ico
+          # These options are not used when passing in a .spec file

--- a/hapticpancake.spec
+++ b/hapticpancake.spec
@@ -9,7 +9,7 @@ datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 
 a = Analysis(
-    ['BridgeApp\\main.py'],
+    ['BridgeApp/main.py'],
     pathex=[],
     binaries=binaries,
     datas=datas,
@@ -41,5 +41,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['Images\\icon.ico'],
+    icon=['Images/icon.ico'],
 )


### PR DESCRIPTION
## In short
* Automatically generate Linux and Windows self-contained executables
  * Named after Git tag, commit count, and commit hash
  * Example: `hapticpancake_linux_v0.5.2-7-g7e81902`
* Modify `hapticpancake.spec` to use Unix path separators (also seems to work on Windows)
  * Fixes PyInstaller building on Linux
* Makes use of the following community actions
  * [proudust/gh-describe@v2](https://github.com/proudust/gh-describe )
  * [sayyid5416/pyinstaller@v1](https://github.com/sayyid5416/pyinstaller)

*NOTE: Actions do not run until merged.  You can try merging this to a separate test branch to try it out, or [check the Actions history on my fork](https://github.com/digitalf0x/VRC-Haptic-Pancake/actions ).*

## Rationale

Folks want to try experimental Haptic Pancake changes (e.g. Tundra Tracker explorations) but don't have their own full Python development environment.  This also may help catch some basic breaking changes.

Note that this requires trusting two community GitHub Actions, as linked above.  Official releases may still want to be built locally.

Artifact downloads are not accessible without a GitHub account.  [nightly.link](https://nightly.link/ ) can easily work around this.