### PR TITLE
[Update] Switch to FreeSimpleGUI, update deps

### DIFF
--- a/BridgeApp/app_gui.py
+++ b/BridgeApp/app_gui.py
@@ -1,4 +1,4 @@
-import PySimpleGUI as sg
+import FreeSimpleGUI as sg
 import webbrowser
 
 from app_config import AppConfig, PatternConfig
@@ -39,6 +39,7 @@ class GUIRenderer:
         self.restart_osc_event = restart_osc_event
         self.refresh_trackers_event = refresh_trackers_event
         self.config = app_config
+        self.shutting_down = False
         self.window = None
         self.trackers = []
         self.osc_status_bar = sg.Text('', key=KEY_OSC_STATUS_BAR)
@@ -165,10 +166,11 @@ class GUIRenderer:
             self.osc_status_bar.DisplayText = message
             self.osc_status_bar.TextColor = text_color
             return
-        try:
-            self.osc_status_bar.update(message, text_color=text_color)
-        except Exception as e:
-            print("[GUI] Failed to update server status bar.")
+        if not self.shutting_down:
+            try:
+                self.osc_status_bar.update(message, text_color=text_color)
+            except Exception as e:
+                print("[GUI] Failed to update server status bar.")
 
     def run(self):
         if self.window is None:
@@ -181,6 +183,7 @@ class GUIRenderer:
 
         # React to Event
         if event == sg.WIN_CLOSED or event == 'Exit':  # if user closes window or clicks cancel
+            self.shutting_down = True
             print("[GUI] Closing application.")
             return False
         if event[0] == KEY_BTN_TEST:

--- a/BridgeApp/requirements.txt
+++ b/BridgeApp/requirements.txt
@@ -1,6 +1,6 @@
-pysimplegui==4.60.5
-openvr==1.26.701
-pydantic==2.5.3
-pyserial==3.5
-python-osc==1.8.3
-websockets==12.0
+freesimplegui~=5.1.0
+openvr~=1.26.701
+pydantic~=2.8.0
+pyserial~=3.5
+python-osc~=1.8.3
+websockets~=12.0


### PR DESCRIPTION
## In short
* Switch from PySimpleGUI to [FreeSimpleGUI](https://github.com/spyoungtech/FreeSimpleGUI )
   * Avoids phone-home license checking
   * Avoids everyone needing to register a hobbyist license key once a year
   * Places trust in [`spyoungtech`](https://github.com/spyoungtech )
   * Add a workaround for a normally-helpful exception popup dialog
* Update dependencies, use "compatible versioning"
   * Switch to allowing compatible version updates automatically
   * Enables CI to test updates in advance of releases or old versions going away
   * Going by PySimpleGUI, it looks like exact versions aren't locked in time anyways

## Rationale

PySimpleGUI now costs $99 for a license key which cannot be shared (would require some central secret management), and now includes code to phone home, self-update, etc, which feels concerning.

Considering Haptic Pancake is fairly simple, just switch to FreeSimpleGUI instead.  If we want more complex features (e.g. resizable windows with a smoother layout), I'd encourage using a "full" toolkit, such as Qt.

### Breaking changes

Py/FreeSimpleGUI now checks for invalid updates to the GUI once a window is closed and pops up a dialog box instead of letting the exception occur as expected.  There's a `shutting_down` check to stop text updates once closing the main window, but that might not be everything.

I would **encourage testing this personally before making a release** with this change.

See https://docs.pysimplegui.com/en/latest/cookbook/original/exception_handling/

### Context
* [PSA: PySimpleGUI has deleted [almost] all old LGPL versions from PyPI; update your dependencies](https://www.reddit.com/r/Python/comments/1d8d4iv/psa_pysimplegui_has_deleted_almost_all_old_lgpl/ )