### PR TITLE
Added a whitelist for supported models

### DIFF
--- a/BridgeApp/main.py
+++ b/BridgeApp/main.py
@@ -12,6 +12,7 @@ vr: OpenVRTracker = None
 config: AppConfig = None
 gui: GUIRenderer = None
 
+supported_models = ["VIVE Tracker 3.0 MV"]
 
 def main():
     print(f"[Main] Using Python: {platform.python_version()}")
@@ -75,6 +76,8 @@ def refresh_tracker_list():
         return
 
     for device in vr.query_devices():
+        if device.model not in supported_models:
+            continue
         gui.add_tracker(device.index, device.serial, device.model)
 
     # Debug tracker (Uncomment this for debug purposes)


### PR DESCRIPTION
This PR adds a whitelist for supported tracker models to prevent unsupported trackers like Standable or Amethyst  from cluttering up the UI with unsupported tracker models.

### The whitelist currently only contains the model number for the Vive 3.0 Trackers as that's all I have access to.

If you have a different supported tracker, please post a comment with the output of `device.model`!