### PR TITLE
[Fix] ci: Monthly build check for deps, artifact

### DIFF
--- a/.github/workflows/build-pyinstall.yml
+++ b/.github/workflows/build-pyinstall.yml
@@ -2,14 +2,14 @@ name: Build PyInstall
 # Based on https://github.com/sayyid5416/pyinstaller
 
 on:
-  # All branches:
-  [ push, pull_request, workflow_dispatch ]
-  # "main" only:
-  #push:
-  #  branches: [ "main" ]
-  #pull_request:
-  #  branches: [ "main" ]
-  #workflow_dispatch:
+  push:
+  pull_request:
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run at 06:21 UTC on the 8th of every month (odd time to reduce load)
+    - cron: '21 06 8 * *'
+  workflow_dispatch:
+  # To limit to "main" branch, add to above...
   #  branches: [ "main" ]
 
 # Get git tag info via GitHub API due to shallow clone:


### PR DESCRIPTION
## In short
* [Schedule monthly build of project](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#schedule )
  * 8th of month, `06:21` UTC for morning-ish, odd time to reduce load
  * Helps catch dependency changes that break the build
  * Keeps latest (unstable) Bridge App downloads available (artifacts expire after 90 days)