### PR TITLE
[Fix] deps: Add setuptools for running from source

### DIFF
--- a/BridgeApp/requirements.txt
+++ b/BridgeApp/requirements.txt
@@ -3,4 +3,5 @@ openvr~=1.26.701
 pydantic~=2.8.0
 pyserial~=3.5
 python-osc~=1.8.3
+setuptools~=75.3
 websockets~=12.0


### PR DESCRIPTION
## In short

* Add [`setuptools`](https://setuptools.pypa.io/en/latest/userguide/quickstart.html ) to `requirements.txt` for running BridgeApp from source in Virtual Environment
  * Fixes OpenVR raising an error when running on Python 3.12 with Kubuntu 24.04
  * Might not be the most correct solution

## Examples
### Fixed error message
```
Traceback (most recent call last):
  File "[...]/VRC-Haptic-Pancake/BridgeApp/main.py", line 6, in <module>
    from target_ovr import OpenVRTracker
  File "[...]/VRC-Haptic-Pancake/BridgeApp/target_ovr.py", line 1, in <module>
    import openvr
  File "[...]/ignored-from-repo-venv/lib/python3.12/site-packages/openvr/__init__.py", line 8, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

### Run-from-source script
```sh
#!/bin/bash

# Find path
_LOCAL_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"

# Fetch repository with GitHub source code download, or…
# git clone "https://github.com/Z4urce/VRC-Haptic-Pancake.git"
# cd "VRC-Haptic-Pancake"

# Enter software directory
cd "$_LOCAL_DIR/VRC-Haptic-Pancake/"

# Build and activate a Python virtual environment to keep your system clean
if [ ! -d "ignored-from-repo-venv" ]; then
    python3 -m venv "ignored-from-repo-venv"
fi
source "ignored-from-repo-venv/bin/activate"

# Install/update dependencies into the venv
pip3 install -r "BridgeApp/requirements.txt"

# Run app
python3 BridgeApp/main.py

# NOTE₁: You need to be inside the Python venv for this to work.  Redo the
#    "source […]" command if you're running this a second time, or just save this as
#    a "run-linux.sh" command in the root of the repository.

# NOTE₂: the app might segfault without tracing enabled for some reason
#    You might need to run it like so - this slows it down:
#
#python3 -m trace --count --coverdir=/dev/null BridgeApp/main.py

```