### PR TITLE
[Fix] ci: Use Unix paths for PyInstaller spec

### DIFF
--- a/hapticpancake.spec
+++ b/hapticpancake.spec
@@ -9,7 +9,7 @@ datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 
 a = Analysis(
-    ['BridgeApp\\main.py'],
+    ['BridgeApp/main.py'],
     pathex=[],
     binaries=binaries,
     datas=datas,
@@ -41,5 +41,5 @@ exe = EXE(
     target_arch=None,
     codesign_identity=None,
     entitlements_file=None,
-    icon=['Images\\icon.ico'],
+    icon=['Images/icon.ico'],
 )


### PR DESCRIPTION
## In short
* PyInstaller seems to need Unix paths to build on both Windows and Linux
   * Their documentation might be wrong? [`The strings may use either / or \ as the path separator`](https://pyinstaller.org/en/stable/spec-files.html#adding-data-files )
   * Unix paths still appear to generate working Windows builds

## Details

PyInstaller claims that either Windows or Unix paths should work, and the old method of using Unix paths appeared to successfully generate working Windows binaries.  I'm not sure why using Windows paths fails, though.

For now, use Unix paths.  If necessary, `os.path.join(...)` could be used instead.

One example is [Bubble Tanks 2 which has a Windows build](https://ildarryabkov.itch.io/bubble-tanks-2 ) and yet [it uses `/` for path separators](https://github.com/IldarRyabkov/BubbleTanks2/blob/main/src/setup.spec ).