### PR TITLE
[Update] Auto-refresh every 30s, add tracker count

### DIFF
--- a/BridgeApp/main.py
+++ b/BridgeApp/main.py
@@ -71,7 +71,7 @@ def restart_bridge_server():
     start_bridge_server()
 
 
-def refresh_tracker_list():
+def refresh_tracker_list(quiet_refresh=False):
     if vr is None or gui is None:
         return
 
@@ -83,7 +83,10 @@ def refresh_tracker_list():
 
     # Debug tracker (Uncomment this for debug purposes)
     # gui.add_tracker("T35T-53R1AL", "Test Model 1.0")
-    print("[Main] Tracker list refreshed")
+    if not quiet_refresh:
+        print("[Main] Tracker list refreshed")
+
+    gui.update_tracker_counts()
 
 
 def add_external_target(external_type):

--- a/BridgeApp/main.py
+++ b/BridgeApp/main.py
@@ -75,11 +75,13 @@ def refresh_tracker_list(quiet_refresh=False):
     if vr is None or gui is None:
         return
 
-    for device in vr.query_devices():
-        gui.add_tracker(device.serial, device.model, True)
-        
-    for serial, tracker_config in config.tracker_config_dict.items():
-        gui.add_tracker(serial, "- OFFLINE", False)
+    for device in vr.query_devices(quiet_refresh):
+        gui.add_tracker(device.serial, device.model, True, quiet_refresh)
+
+    #for serial, tracker_config in config.tracker_config_dict.items():
+    #    gui.add_tracker(serial, "- OFFLINE", False, quiet_refresh)
+    #
+    # FIXME: This needs to properly update existing UI elements!
 
     # Debug tracker (Uncomment this for debug purposes)
     # gui.add_tracker("T35T-53R1AL", "Test Model 1.0")

--- a/BridgeApp/target_ovr.py
+++ b/BridgeApp/target_ovr.py
@@ -11,7 +11,7 @@ class OpenVRTracker:
         self.vr = None
         self.config = config
 
-    def try_init_openvr(self):
+    def try_init_openvr(self, quiet_refresh=False):
         if self.vr is not None:
             return True
         try:
@@ -20,11 +20,12 @@ class OpenVRTracker:
             print("[OpenVRTracker] Successfully initialized.")
             return True
         except:
-            print("[OpenVRTracker] Failed to initialize OpenVR.")
+            if not quiet_refresh:
+                print("[OpenVRTracker] Failed to initialize OpenVR.")
             return False
 
-    def query_devices(self):
-        if not self.try_init_openvr():
+    def query_devices(self, quiet_refresh=False):
+        if not self.try_init_openvr(quiet_refresh):
             return self.devices
 
         poses = self.vr.getDeviceToAbsoluteTrackingPose(openvr.TrackingUniverseStanding, 0,


### PR DESCRIPTION
## In short
* Auto-refresh tracker list every 30 seconds
  * Should hopefully not be performance intensive..?
  * Hide console log messages about duplicate devices during auto-refresh
* Add online device count after `Devices:` text
  * Makes it easier to tell at a glance if all trackers are active
* Temporarily disable offline device listing
  * In current state, offline listing breaks updating with online trackers

## Details

Every 30 seconds, refresh the tracker list.  This allows starting Haptic Pancake without worrying about having to click the refresh button afterwards.  The refresh button still exists in case you want immediate feedback.

This paves the way for future auto-starting with SteamVR.

Add a counter for online devices to the `Devices: #` header, making it easy to tell at a glance how many trackers are connected.
![Screenshot showing the "Devices:" header with 8 active trackers, e.g. "Devices: 8"](https://github.com/user-attachments/assets/413b23f3-52ce-4784-be11-99121b00e02c)

When offline device listing is finished, this can instead say `X / Y` where it's `X` online of `Y` known devices.