### PR TITLE
Theme support

### DIFF
--- a/BridgeApp/app_config.py
+++ b/BridgeApp/app_config.py
@@ -86,6 +86,7 @@ class AppConfig(BaseModel):
     server_port: int = 9001
     pattern_config_list: List[PatternConfig] = []
     tracker_config_dict: Dict[str, TrackerConfig] = {}
+    theme: str = "DarkAmber"
 
     # OBSOLETE - Will delete these in the next version
     tracker_to_osc: Dict[str, str] = {}

--- a/BridgeApp/app_gui.py
+++ b/BridgeApp/app_gui.py
@@ -286,6 +286,7 @@ class GUIRenderer:
 
         # Manually readd osc status
         self.osc_status_bar.update(osc_status_bar_text, text_color=osc_status_bar_color)
+        self.osc_status_bar.TextColor = osc_status_bar_color
 
         # Mark layout as dirty
         self.layout_dirty = True

--- a/BridgeApp/main.py
+++ b/BridgeApp/main.py
@@ -41,9 +41,6 @@ def main():
     # Add trackers to GUI
     refresh_tracker_list()
 
-    # Add footer
-    gui.add_footer()
-
     # Main GUI loop here
     while gui.run():
         pass


### PR DESCRIPTION
Allows theme switching to any of the default [PySimpleGUI themes](https://docs.pysimplegui.com/en/latest/documentation/module/themes/) as well as custom themes that can be added (hardcoded) in code. Right now, there is an "HOVR" theme which was the theme used in my H.O.V.R. fork; a nice black and purple theme. The default theme is DarkAmber like before.

To switch theme with PySimpleGUI, we need to close the window, recreate the layout, and recreate the window. Thus, the footer method has been merged with the build_layout method since I don't see any reason for it to be separate from the rest.

Everytime the theme is changed, trackers are refreshed using the function from main since caching them and displaying them again is too much trouble and too much potential future breakage.

The theme is saved as a string in config and a try/except is used to prevent any kind of breakage from renaming/adding/removing/moving custom themes around.

Also:
- Removed transparency on the window (100% opacity instead of 95%)
- Commented out the "Calibrate" and "Add External device" buttons since they don't do anything yet except bloat the UI. They can just be uncommented later when their features are implemented.

<img width="566" height="962" alt="python_D615gneHAg" src="https://github.com/user-attachments/assets/5d335920-7a1c-4e2b-a561-bc402522158e" />
