### PR TITLE
Start with SteamVR setting

### DIFF
--- a/BridgeApp/app_config.py
+++ b/BridgeApp/app_config.py
@@ -86,6 +86,7 @@ class AppConfig(BaseModel):
     server_port: int = 9001
     pattern_config_list: List[PatternConfig] = []
     tracker_config_dict: Dict[str, TrackerConfig] = {}
+    start_with_steamvr: bool = False
 
     # OBSOLETE - Will delete these in the next version
     tracker_to_osc: Dict[str, str] = {}

--- a/BridgeApp/app_gui.py
+++ b/BridgeApp/app_gui.py
@@ -23,6 +23,7 @@ KEY_BTN_TEST = '-BTN-TEST-'
 KEY_BTN_CALIBRATE = '-BTN-CALIBRATE-'
 KEY_BTN_ADD_EXTERNAL = '-BTN-ADD-EXTERNAL-'
 KEY_BATTERY_THRESHOLD = '-BATTERY-'
+KEY_START_WITH_STEAMVR = '-START-WITH-STEAMVR-'
 
 # Pattern Config
 KEY_PROXIMITY = '-PROXY-'
@@ -39,12 +40,13 @@ TIMER_REFRESH_MS = 30 * 1000
 
 class GUIRenderer:
     def __init__(self, app_config: AppConfig, tracker_test_event,
-                 restart_osc_event, refresh_trackers_event, add_external_event):
+                 restart_osc_event, refresh_trackers_event, add_external_event, setup_autostart_event):
         sg.theme('DarkAmber')
         self.tracker_test_event = tracker_test_event
         self.restart_osc_event = restart_osc_event
         self.refresh_trackers_event = refresh_trackers_event
         self.add_external_event = add_external_event
+        self.setup_autostart_event = setup_autostart_event
 
         self.config = app_config
         self.shutting_down = False
@@ -68,6 +70,8 @@ class GUIRenderer:
                                       self.config.pattern_config_list[VibrationPattern.VELOCITY]))
 
         self.layout = [
+            [sg.Text('App settings:', font='_ 14')],
+            [sg.Checkbox("Start with SteamVR", default=self.config.start_with_steamvr, key=KEY_START_WITH_STEAMVR, enable_events=True)],
             [sg.Text('Bridge settings:', font='_ 14')],
             [sg.Text("Server Type:"),
              sg.InputCombo(LIST_SERVER_TYPE, LIST_SERVER_TYPE[self.config.server_type], key=KEY_SERVER_TYPE)],
@@ -302,6 +306,12 @@ class GUIRenderer:
 
         for tracker in self.trackers:
             self.update_tracker_config(values, tracker)
+
+        # Update app settings
+        old_start_with_steamvr = self.config.start_with_steamvr
+        self.config.start_with_steamvr = values[KEY_START_WITH_STEAMVR]
+        if old_start_with_steamvr != self.config.start_with_steamvr:
+            self.setup_autostart_event(self.config.start_with_steamvr)
 
         # Update OSC Addresses
         self.config.server_type = LIST_SERVER_TYPE.index(values[KEY_SERVER_TYPE])

--- a/BridgeApp/main.py
+++ b/BridgeApp/main.py
@@ -3,12 +3,12 @@ from app_gui import GUIRenderer
 from server_base import ServerBase
 from server_osc import VRChatOSCReceiver
 from server_websocket import ResoniteWebSocketServer
-from target_ovr import OpenVRTracker
+from target_ovr import OpenVRHandler
 import traceback
 import platform
 
 bridge_server: ServerBase = None
-vr: OpenVRTracker = None
+vr: OpenVRHandler = None
 config: AppConfig = None
 gui: GUIRenderer = None
 external_id: int = 0
@@ -26,7 +26,7 @@ def main():
 
     # Init GUI
     global gui
-    gui = GUIRenderer(config, pulse_test, restart_bridge_server, refresh_tracker_list, add_external_target)
+    gui = GUIRenderer(config, pulse_test, restart_bridge_server, refresh_tracker_list, add_external_target, setup_autostart)
     print("[Main] GUI initialized")
 
     # Start the Server
@@ -36,7 +36,7 @@ def main():
 
     # Init OpenVR
     global vr
-    vr = OpenVRTracker(config)
+    vr = OpenVRHandler(config)
 
     # Add trackers to GUI
     refresh_tracker_list()
@@ -118,6 +118,8 @@ def param_received(address, value):
         if  address in tracker_config.address_list:
             vr.set_strength(serial, value)
 
+def setup_autostart(autostart: bool):
+    vr.setup_autostart(autostart=autostart)
 
 if __name__ == '__main__':
     try:

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,2 @@
 pyinstaller -wF --collect-all openvr --name hapticpancake --icon=Images\icon.ico BridgeApp/main.py
+copy "manifest.vrmanifest" "dist\manifest.vrmanifest"

--- a/manifest.vrmanifest
+++ b/manifest.vrmanifest
@@ -1,0 +1,16 @@
+{
+	"source" : "builtin",
+	"applications": [{
+		"app_key": "hapticpancake",
+		"launch_type": "binary",
+		"binary_path_windows": "hapticpancake.exe",
+		"is_dashboard_overlay": true,
+
+		"strings": {
+			"en_us": {
+				"name": "Haptic Pancake Bridge",
+				"description": "Bridge software to enable haptic feedback on trackers in VRChat and Resonite"
+			}
+		}
+	}]
+}


### PR DESCRIPTION
Adds an option to register a vrmanifest and enable autostart. Manifest needs to be shipped alongside the .exe since temporary paths from onefile do not seem to work.